### PR TITLE
Patch add icons

### DIFF
--- a/icons/car-15.svg
+++ b/icons/car-15.svg
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 19.2.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 width="15px" height="15px" viewBox="0 0 15 15" style="enable-background:new 0 0 15 15;" xml:space="preserve">
+<path d="M14,7c-0.004-0.6904-0.4787-1.2889-1.15-1.45l-1.39-3.24l0,0l0,0l0,0C11.3833,2.1233,11.2019,2.001,11,2H4
+	C3.8124,2.0034,3.6425,2.1115,3.56,2.28l0,0l0,0l0,0L2.15,5.54C1.475,5.702,0.9994,6.3059,1,7v3.5h1v1c0,0.5523,0.4477,1,1,1
+	s1-0.4477,1-1v-1h7v1c0,0.5523,0.4477,1,1,1s1-0.4477,1-1v-1h1V7z M4.3,3h6.4l1.05,2.5h-8.5L4.3,3z M3,9C2.4477,9,2,8.5523,2,8
+	s0.4477-1,1-1s1,0.4477,1,1S3.5523,9,3,9z M12,9c-0.5523,0-1-0.4477-1-1s0.4477-1,1-1s1,0.4477,1,1S12.5523,9,12,9z"/>
+</svg>

--- a/icons/car-15.svg
+++ b/icons/car-15.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Generator: Adobe Illustrator 19.2.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+<svg version="1.1" fill='#2979ff' xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
 	 width="15px" height="15px" viewBox="0 0 15 15" style="enable-background:new 0 0 15 15;" xml:space="preserve">
 <path d="M14,7c-0.004-0.6904-0.4787-1.2889-1.15-1.45l-1.39-3.24l0,0l0,0l0,0C11.3833,2.1233,11.2019,2.001,11,2H4
 	C3.8124,2.0034,3.6425,2.1115,3.56,2.28l0,0l0,0l0,0L2.15,5.54C1.475,5.702,0.9994,6.3059,1,7v3.5h1v1c0,0.5523,0.4477,1,1,1

--- a/icons/circle-15.svg
+++ b/icons/circle-15.svg
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 19.2.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 width="15px" height="15px" viewBox="0 0 15 15" style="enable-background:new 0 0 15 15;" xml:space="preserve">
+<path d="M14,7.5c0,3.5899-2.9101,6.5-6.5,6.5S1,11.0899,1,7.5S3.9101,1,7.5,1S14,3.9101,14,7.5z"/>
+</svg>

--- a/icons/circle-15.svg
+++ b/icons/circle-15.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Generator: Adobe Illustrator 19.2.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+<svg version="1.1" fill='#2979ff' xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
 	 width="15px" height="15px" viewBox="0 0 15 15" style="enable-background:new 0 0 15 15;" xml:space="preserve">
 <path d="M14,7.5c0,3.5899-2.9101,6.5-6.5,6.5S1,11.0899,1,7.5S3.9101,1,7.5,1S14,3.9101,14,7.5z"/>
 </svg>

--- a/icons/landmark-15.svg
+++ b/icons/landmark-15.svg
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 19.2.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 width="15px" height="15px" viewBox="0 0 15 15" style="enable-background:new 0 0 15 15;" xml:space="preserve">
+<path d="M12.5,12H12v-0.5c0-0.3-0.2-0.5-0.5-0.5H11V6h1l1-2c-1,0.1-2,0.1-3,0C9.2,3.4,8.6,2.8,8,2V1.5C8,1.2,7.8,1,7.5,1
+	S7,1.2,7,1.5V2C6.4,2.8,5.8,3.4,5,4C4,4.1,3,4.1,2,4l1,2h1v5c0,0-0.5,0-0.5,0C3.2,11,3,11.2,3,11.5V12H2.5C2.2,12,2,12.2,2,12.5V13
+	h11v-0.5C13,12.2,12.8,12,12.5,12z M7,11H5V6h2V11z M10,11H8V6h2V11z"/>
+<title>landmark</title>
+</svg>

--- a/icons/landmark-15.svg
+++ b/icons/landmark-15.svg
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Generator: Adobe Illustrator 19.2.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
-<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+<svg version="1.1" fill='#2979ff'  xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
 	 width="15px" height="15px" viewBox="0 0 15 15" style="enable-background:new 0 0 15 15;" xml:space="preserve">
 <path d="M12.5,12H12v-0.5c0-0.3-0.2-0.5-0.5-0.5H11V6h1l1-2c-1,0.1-2,0.1-3,0C9.2,3.4,8.6,2.8,8,2V1.5C8,1.2,7.8,1,7.5,1
 	S7,1.2,7,1.5V2C6.4,2.8,5.8,3.4,5,4C4,4.1,3,4.1,2,4l1,2h1v5c0,0-0.5,0-0.5,0C3.2,11,3,11.2,3,11.5V12H2.5C2.2,12,2,12.2,2,12.5V13

--- a/icons/school-15.svg
+++ b/icons/school-15.svg
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 19.2.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 width="15px" height="15px" viewBox="0 0 15 15" style="enable-background:new 0 0 15 15;" xml:space="preserve">
+<path d="M11,13v-1h2v-1H9.5v-1H13V9h-2V8h2V7h-2V6h2V5H9.5V4H13V3h-2V2h2V1H8v13h5v-1H11z M6,11H2V1h4V11z M6,12l-2,2l-2-2H6z"/>
+</svg>

--- a/icons/school-15.svg
+++ b/icons/school-15.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Generator: Adobe Illustrator 19.2.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+<svg version="1.1" fill='#2979ff' xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
 	 width="15px" height="15px" viewBox="0 0 15 15" style="enable-background:new 0 0 15 15;" xml:space="preserve">
 <path d="M11,13v-1h2v-1H9.5v-1H13V9h-2V8h2V7h-2V6h2V5H9.5V4H13V3h-2V2h2V1H8v13h5v-1H11z M6,11H2V1h4V11z M6,12l-2,2l-2-2H6z"/>
 </svg>

--- a/icons/town-hall-15.svg
+++ b/icons/town-hall-15.svg
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 19.2.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1"
+	 id="svg4619" inkscape:version="0.91+devel+osxmenu r12911" sodipodi:docname="town-hall-15.svg" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns:svg="http://www.w3.org/2000/svg"
+	 xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="15px" height="15px"
+	 viewBox="0 0 15 15" style="enable-background:new 0 0 15 15;" xml:space="preserve">
+<path id="path7509" d="M7.5,0L1,3.4453V4h13V3.4453L7.5,0z M2,5v5l-1,1.5547V13h13v-1.4453L13,10V5H2z M4,6h1v5.5H4V6z M7,6h1v5.5H7
+	V6z M10,6h1v5.5h-1V6z"/>
+</svg>

--- a/icons/town-hall-15.svg
+++ b/icons/town-hall-15.svg
@@ -2,7 +2,7 @@
 <!-- Generator: Adobe Illustrator 19.2.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
 <svg version="1.1"
-	 id="svg4619" inkscape:version="0.91+devel+osxmenu r12911" sodipodi:docname="town-hall-15.svg" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns:svg="http://www.w3.org/2000/svg"
+	 fill='#2979ff' inkscape:version="0.91+devel+osxmenu r12911" sodipodi:docname="town-hall-15.svg" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns:svg="http://www.w3.org/2000/svg"
 	 xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="15px" height="15px"
 	 viewBox="0 0 15 15" style="enable-background:new 0 0 15 15;" xml:space="preserve">
 <path id="path7509" d="M7.5,0L1,3.4453V4h13V3.4453L7.5,0z M2,5v5l-1,1.5547V13h13v-1.4453L13,10V5H2z M4,6h1v5.5H4V6z M7,6h1v5.5H7

--- a/icons/triangle-15.svg
+++ b/icons/triangle-15.svg
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 19.2.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1"
+	 id="svg4619" inkscape:version="0.91+devel+osxmenu r12911" sodipodi:docname="triangle-15.svg" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns:svg="http://www.w3.org/2000/svg"
+	 xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="15px" height="15px"
+	 viewBox="0 0 15 15" style="enable-background:new 0 0 15 15;" xml:space="preserve">
+<path id="path21090-9" inkscape:connector-curvature="0" sodipodi:nodetypes="sscsssscss" d="M7.5385,2
+	C7.2437,2,7.0502,2.1772,6.9231,2.3846l-5.8462,9.5385C1,12,1,12.1538,1,12.3077C1,12.8462,1.3846,13,1.6923,13h11.6154
+	C13.6923,13,14,12.8462,14,12.3077c0-0.1538,0-0.2308-0.0769-0.3846L8.1538,2.3846C8.028,2.1765,7.7882,2,7.5385,2z"/>
+</svg>

--- a/icons/triangle-15.svg
+++ b/icons/triangle-15.svg
@@ -2,7 +2,7 @@
 <!-- Generator: Adobe Illustrator 19.2.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
 <svg version="1.1"
-	 id="svg4619" inkscape:version="0.91+devel+osxmenu r12911" sodipodi:docname="triangle-15.svg" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns:svg="http://www.w3.org/2000/svg"
+	 fill='#2979ff' inkscape:version="0.91+devel+osxmenu r12911" sodipodi:docname="triangle-15.svg" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns:svg="http://www.w3.org/2000/svg"
 	 xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="15px" height="15px"
 	 viewBox="0 0 15 15" style="enable-background:new 0 0 15 15;" xml:space="preserve">
 <path id="path21090-9" inkscape:connector-curvature="0" sodipodi:nodetypes="sscsssscss" d="M7.5385,2

--- a/index.html
+++ b/index.html
@@ -42,27 +42,33 @@
         }
 
         var roadway = new L.Icon({
-            iconUrl: 'icons/car-15.svg'
+            iconUrl: 'icons/car-15.svg',
+            iconSize: [24,24]
         });
 
         var school = new L.Icon({
-            iconUrl: 'icons/school-15.svg'
+            iconUrl: 'icons/school-15.svg',
+            iconSize: [24,24]
         });
 
         var monument = new L.Icon({
-            iconUrl: 'icons/landmark-15.svg'
+            iconUrl: 'icons/landmark-15.svg',
+            iconSize: [24,24]
         });
 
         var courthouse = new L.Icon({
-            iconUrl: 'icons/town-hall-15.svg'
+            iconUrl: 'icons/town-hall-15.svg',
+            iconSize: [24,24]
         });
 
         var county = new L.Icon({
-            iconUrl: 'icons/triangle-15.svg'
+            iconUrl: 'icons/triangle-15.svg',
+            iconSize: [24,24]
         });
 
         var other = new L.Icon({
-            iconUrl: 'icons/circle-15.svg'
+            iconUrl: 'icons/circle-15.svg',
+            iconSize: [24,24]
         });
 
         // make global for access later
@@ -112,26 +118,49 @@
             // create new markerClusterGroup
             var markers = L.markerClusterGroup();
 
-            // loop through all our signals features
-            symbols.features.forEach(function(feature) {
-                // create a new Leaflet marker for each
-                var coords = feature.geometry.coordinates,
-                    marker = L.marker([coords[1], coords[0]], {icon: function(feature) {
-                        var type = feature.properties.category;
-                        return type === 'Monument' ? monument :
-                                type === 'Courthouse' ? courthouse :
-                                type === 'School' ? school :
-                                type === 'Roadway' ? roadway : 
-                                type === 'County' ? county : 
-                                type === 'Other' ? other : monument;
+            // create layerGroup
+            L.geoJson(symbols, {
+                // convert point types to layers
+                pointToLayer: function(feature, latlng) {
+                    
+                    var type = feature.properties.category;
+                    // use switch statement to determine which icon
+                    switch(type) {
+                        case 'Monument':
+                            icon = monument;
+                            break;
+                        case 'Courthouse':
+                            icon = courthouse;
+                            break;
+                        case 'School':
+                            icon = school;
+                            break;
+                        case 'Roadway':
+                            icon = roadway;
+                            break;
+                        case 'County':
+                            icon = county;
+                            break;
+                        default:
+                            icon = other;
+                            break;
                     }
-                });
-                // bind a tooltip to the marker
-                marker.bindTooltip("<b>Monument:</b> " + feature.properties.feature_name + "</br>" + "<b>Year Dedicated:</b> " + feature.properties.year_dedicated + "</br>" + "<b>Side during Civil War:</b> " + feature.properties.side);
-                // add the marker to the markerClusterGroup
-                markers.addLayer(marker);
-
+                    // create the marker icon
+                    var marker = L.marker(latlng, {icon: icon});
+                    // add to the markercluster layergroup
+                    markers.addLayer(marker);
+                    return marker;
+                },
+                onEachFeature(feature, layer) {
+                    var props = feature.properties;
+                    // bind a tooltip to the marker
+                    layer.bindTooltip("<b>Monument:</b> " + props.feature_name + 
+                        "</br>" + "<b>Year Dedicated:</b> " + props.year_dedicated + "</br>" + 
+                        "<b>Side during Civil War:</b> " + props.side);
+                
+                }
             });
+            
             // add the markerClusterGroup to the map
             map.addLayer(markers);
 

--- a/index.html
+++ b/index.html
@@ -116,7 +116,16 @@
             symbols.features.forEach(function(feature) {
                 // create a new Leaflet marker for each
                 var coords = feature.geometry.coordinates,
-                    marker = L.marker([coords[1], coords[0]]);
+                    marker = L.marker([coords[1], coords[0]], {icon: function(feature) {
+                        var type = feature.properties.category;
+                        return type === 'Monument' ? monument :
+                                type === 'Courthouse' ? courthouse :
+                                type === 'School' ? school :
+                                type === 'Roadway' ? roadway : 
+                                type === 'County' ? county : 
+                                type === 'Other' ? other : monument;
+                    }
+                });
                 // bind a tooltip to the marker
                 marker.bindTooltip("<b>Monument:</b> " + feature.properties.feature_name + "</br>" + "<b>Year Dedicated:</b> " + feature.properties.year_dedicated + "</br>" + "<b>Side during Civil War:</b> " + feature.properties.side);
                 // add the marker to the markerClusterGroup

--- a/index.html
+++ b/index.html
@@ -41,27 +41,27 @@
             fillOpacity: 1
         }
 
-        var roadway = L.icon({
+        var roadway = new L.Icon({
             iconUrl: 'icons/car-15.svg'
         });
 
-        var school = L.icon({
+        var school = new L.Icon({
             iconUrl: 'icons/school-15.svg'
         });
 
-        var monument = L.icon({
+        var monument = new L.Icon({
             iconUrl: 'icons/landmark-15.svg'
         });
 
-        var courthouse = L.icon({
+        var courthouse = new L.Icon({
             iconUrl: 'icons/town-hall-15.svg'
         });
 
-        var county = L.icon({
+        var county = new L.Icon({
             iconUrl: 'icons/triangle-15.svg'
         });
 
-        var other = L.icon({
+        var other = new L.Icon({
             iconUrl: 'icons/circle-15.svg'
         });
 

--- a/index.html
+++ b/index.html
@@ -41,6 +41,30 @@
             fillOpacity: 1
         }
 
+        var roadway = L.icon({
+            iconUrl: 'icons/car-15.svg'
+        });
+
+        var school = L.icon({
+            iconUrl: 'icons/school-15.svg'
+        });
+
+        var monument = L.icon({
+            iconUrl: 'icons/landmark-15.svg'
+        });
+
+        var courthouse = L.icon({
+            iconUrl: 'icons/town-hall-15.svg'
+        });
+
+        var county = L.icon({
+            iconUrl: 'icons/triangle-15.svg'
+        });
+
+        var other = L.icon({
+            iconUrl: 'icons/circle-15.svg'
+        });
+
         // make global for access later
         var choroLayer;
 


### PR DESCRIPTION
Note that I branched this from your add-icons-branch. You can either merge this back into that one and then into master, or likely just directly back into master.

I added a fill='#2979ff' property to each of the icons. We already have a lot of color going on, so maybe we don't want to use a separate color for monuments too. It's good to double-encode icons like this sometimes, but then we'd want to shift the color palette to something more neutral.